### PR TITLE
Make default builder names lowercase.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ repeat this over and over.
     from ftw.builder import Builder
 
     def test_foo(self):
-        folder = create(Builder('Folder')
+        folder = create(Builder('folder')
                         .titled('My Folder')
                         .in_state('published'))
 
@@ -66,7 +66,7 @@ Use the builder for creating objects in your tests:
         layer = MY_PACKAGE_INTEGRATION_TESTING
 
         def test_folder_is_well_titled(self):
-            folder = create(Builder('Folder')
+            folder = create(Builder('folder')
                             .titled('My Folder')
                             .in_state('published'))
 
@@ -151,9 +151,9 @@ your types or extend existing builders.
 
 The built-in builders are:
 
-- ``Folder`` - creates an Archetypes folder
-- ``Page`` (or ``Document``) - creates an Archetypes page (alias Document)
-- ``File`` - creates a File
+- ``folder`` - creates an Archetypes folder
+- ``page`` (or ``Document``) - creates an Archetypes page (alias Document)
+- ``file`` - creates a File
 
 Attaching files
 +++++++++++++++
@@ -163,10 +163,10 @@ with dummy content:
 
 .. code:: python
 
-    file1 = create(Builder('File')
+    file1 = create(Builder('file')
                    .with_dummy_content())
 
-    file2 = create(Builder('File')
+    file2 = create(Builder('file')
                    .attach_file_containing('File content', name='filename.pdf')
 
 
@@ -195,7 +195,7 @@ Set the ``portal_type`` and your own methods.
             self.arguments['text'] = text
             return self
 
-    builder_registry.register('News', NewsBuilder)
+    builder_registry.register('news', NewsBuilder)
 
 
 Creating Dexterity builders
@@ -244,7 +244,7 @@ the ``force`` flag:
 
 .. code:: python
 
-    builder_registry.register('File', CustomFileBuilder, force=True)
+    builder_registry.register('file', CustomFileBuilder, force=True)
 
 
 Development / Tests

--- a/ftw/builder/archetypes.py
+++ b/ftw/builder/archetypes.py
@@ -37,15 +37,15 @@ class FolderBuilder(ArchetypesBuilder):
 
     portal_type = 'Folder'
 
-builder_registry.register('Folder', FolderBuilder)
+builder_registry.register('folder', FolderBuilder)
 
 
 class PageBuilder(ArchetypesBuilder):
 
     portal_type = 'Document'
 
-builder_registry.register('Page', PageBuilder)
-builder_registry.register('Document', PageBuilder)
+builder_registry.register('page', PageBuilder)
+builder_registry.register('document', PageBuilder)
 
 
 class FileBuilder(ArchetypesBuilder):
@@ -66,4 +66,4 @@ class FileBuilder(ArchetypesBuilder):
         self.attach_file_containing("Test data")
         return self
 
-builder_registry.register('File', FileBuilder)
+builder_registry.register('file', FileBuilder)

--- a/ftw/builder/tests/test_archetypes.py
+++ b/ftw/builder/tests/test_archetypes.py
@@ -6,53 +6,53 @@ from ftw.builder.tests import IntegrationTestCase
 class TestArchetypesBuilder(IntegrationTestCase):
 
     def test_unmarks_creation_flag_with_procjessForm_by_default(self):
-        folder = create(Builder('Folder'))
+        folder = create(Builder('folder'))
         self.assertFalse(folder.checkCreationFlag(),
                          'Creation flag should be False after creation by default.')
 
     def test_calling_processForm_can_be_disabled(self):
-        folder = create(Builder('Folder'), processForm=False)
+        folder = create(Builder('folder'), processForm=False)
         self.assertTrue(folder.checkCreationFlag(),
                         'Creation flag should be True when disabling processForm')
 
     def test_object_id_is_chosen_from_title_automatically(self):
-        folder1 = create(Builder('Folder').titled('Foo'))
+        folder1 = create(Builder('folder').titled('Foo'))
         self.assertEqual('foo', folder1.getId())
 
-        folder2 = create(Builder('Folder').titled('Foo'))
+        folder2 = create(Builder('folder').titled('Foo'))
         self.assertEqual('foo-1', folder2.getId())
 
     def test_object_id_can_be_set(self):
-        folder = create(Builder('Folder').with_id('bar'))
+        folder = create(Builder('folder').with_id('bar'))
         self.assertEqual('bar', folder.getId())
 
 
 class TestATFolderBuilder(IntegrationTestCase):
 
     def test_creates_a_folder(self):
-        folder = create(Builder('Folder'))
+        folder = create(Builder('folder'))
         self.assertEquals('Folder', folder.portal_type)
 
 
 class TestATPageBuilder(IntegrationTestCase):
 
     def test_Page_builder_creates_a_Document(self):
-        page = create(Builder('Page'))
+        page = create(Builder('page'))
         self.assertEquals('Document', page.portal_type)
 
     def test_alias_Document_also_works_for_creating_documents(self):
-        page = create(Builder('Document'))
+        page = create(Builder('document'))
         self.assertEquals('Document', page.portal_type)
 
 
 class TestATFileBuilder(IntegrationTestCase):
 
     def test_creates_a_File_object(self):
-        file_ = create(Builder('File'))
+        file_ = create(Builder('file'))
         self.assertEquals('File', file_.portal_type)
 
     def test_file_data_can_be_attached(self):
-        file_ = create(Builder('File')
+        file_ = create(Builder('file')
                        .attach_file_containing('Data Data', 'data.txt'))
 
         self.assertEquals(
@@ -63,7 +63,7 @@ class TestATFileBuilder(IntegrationTestCase):
              'data': file_.getFile().data})
 
     def test_dummy_content_can_be_attached(self):
-        file_ = create(Builder('File')
+        file_ = create(Builder('file')
                        .with_dummy_content())
 
         self.assertEquals(

--- a/ftw/builder/tests/test_builder.py
+++ b/ftw/builder/tests/test_builder.py
@@ -10,26 +10,26 @@ from plone import api
 class TestCreatingObjects(IntegrationTestCase):
 
     def test_default_container_is_plone_site(self):
-        folder = create(Builder('Folder'))
+        folder = create(Builder('folder'))
         self.assertEqual(self.portal, aq_parent(aq_inner(folder)))
 
     def test_default_id_is_portal_type(self):
-        folder = create(Builder('Folder'))
+        folder = create(Builder('folder'))
         self.assertEqual('folder', folder.getId())
 
     def test_create_folder_with_title(self):
-        folder = create(Builder('Folder').titled('The Folder'))
+        folder = create(Builder('folder').titled('The Folder'))
         self.assertEqual('The Folder', folder.Title())
         self.assertEqual('the-folder', folder.getId())
 
     def test_changing_workflow_state(self):
         self.set_workflow_chain('Folder', 'simple_publication_workflow')
 
-        normal_folder = create(Builder('Folder'))
+        normal_folder = create(Builder('folder'))
         self.assertEquals('private',
                           api.content.get_state(normal_folder))
 
-        published_folder = create(Builder('Folder').in_state('published'))
+        published_folder = create(Builder('folder').in_state('published'))
         self.assertEquals('published',
                           api.content.get_state(published_folder))
 


### PR DESCRIPTION
The builder names are not the portal types.
This should help to avoid ambiguity and confusion.

/cc @phgross @senny 
