### PR TITLE
Reindex object security when changing workflow state.

### DIFF
--- a/ftw/builder/builder.py
+++ b/ftw/builder/builder.py
@@ -78,3 +78,5 @@ class PloneObjectBuilder(object):
             workflow = wftool.get(workflow_id)
             if hasattr(aq_base(workflow), 'updateRoleMappingsFor'):
                 workflow.updateRoleMappingsFor(obj)
+
+        obj.reindexObjectSecurity()


### PR DESCRIPTION
@phgross can you take a look a this?
We manually set the workflow state, which requires a `reindexObjectSecurity` so that the `allowedRolesAndUsers` index is up to date.
