### PR TITLE
Added reindex after workflow state changes.

### DIFF
--- a/ftw/builder/builder.py
+++ b/ftw/builder/builder.py
@@ -80,3 +80,4 @@ class PloneObjectBuilder(object):
                 workflow.updateRoleMappingsFor(obj)
 
         obj.reindexObjectSecurity()
+        obj.reindexObject(idxs=['review_state'])


### PR DESCRIPTION
When creating a object with a PloneObjectBuilder and using the `in_state` method to put it into an other state than the default, the brain is still in the default workflow state (see testcase for more information). 
Therefore i append an `reindexObject` after changing the workflow state.

@jone could you take a look?
