### PR TITLE
Add `providing()` method to Plone builder.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -159,6 +159,7 @@ setting basic options:
 - ``having(field=value)`` - set the value of any field on the object
 - ``in_state(review_state)`` - set the object into any review state of the workflow
   configured for this type
+- ``providing(interface1, interface2, ...)`` - let the object provide interfaces
 
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
+- Add `providing()` method to Plone builder,
+  letting the object provide interfaces.
+  [jone]
+
 - Don't use IDNormalizer for Mail. It handles Umlauts weird.
   [tschanzt]
 

--- a/ftw/builder/builder.py
+++ b/ftw/builder/builder.py
@@ -3,6 +3,7 @@ from Products.CMFCore.utils import getToolByName
 from ftw.builder import registry
 from ftw.builder import session
 from zope.component.hooks import getSite
+from zope.interface import alsoProvides
 import transaction
 
 
@@ -27,6 +28,7 @@ class PloneObjectBuilder(object):
         self.arguments = {}
         self.review_state = None
         self.modification_date = None
+        self.interfaces = []
 
     def within(self, container):
         self.container = container
@@ -48,6 +50,10 @@ class PloneObjectBuilder(object):
         self.modification_date = modification_date
         return self
 
+    def providing(self, *interfaces):
+        self.interfaces.extend(interfaces)
+        return self
+
     def create(self, **kwargs):
         self.before_create()
         obj = self.create_object(**kwargs)
@@ -58,6 +64,7 @@ class PloneObjectBuilder(object):
         pass
 
     def after_create(self, obj):
+        alsoProvides(obj, *self.interfaces)
         self.change_workflow_state(obj)
 
         if self.modification_date:

--- a/ftw/builder/tests/test_archetypes.py
+++ b/ftw/builder/tests/test_archetypes.py
@@ -1,6 +1,11 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.builder.tests import IntegrationTestCase
+from zope.interface import Interface
+
+
+class IFoo(Interface):
+    pass
 
 
 class TestArchetypesBuilder(IntegrationTestCase):
@@ -25,6 +30,10 @@ class TestArchetypesBuilder(IntegrationTestCase):
     def test_object_id_can_be_set(self):
         folder = create(Builder('folder').with_id('bar'))
         self.assertEqual('bar', folder.getId())
+
+    def test_object_providing_interface(self):
+        folder = create(Builder('folder').providing(IFoo))
+        self.assertTrue(IFoo.providedBy(folder))
 
 
 class TestATFolderBuilder(IntegrationTestCase):

--- a/ftw/builder/tests/test_dexterity.py
+++ b/ftw/builder/tests/test_dexterity.py
@@ -19,6 +19,10 @@ from zope.lifecycleevent.interfaces import IObjectAddedEvent
 from zope.lifecycleevent.interfaces import IObjectCreatedEvent
 
 
+class IFoo(Interface):
+    pass
+
+
 class IBookSchema(Interface):
     title = schema.TextLine(
         title=u'Title',
@@ -118,6 +122,10 @@ class TestDexterityBuilder(DexterityBaseTestCase):
 
         self.assertEquals(u'hugo.boss', book.author)
         self.assertEquals((u'hugo.boss', ), book.listCreators())
+
+    def test_object_providing_interface(self):
+        book = create(Builder('book').providing(IFoo))
+        self.assertTrue(IFoo.providedBy(book))
 
 
 @adapter(IObjectCreatedEvent)


### PR DESCRIPTION
With the `providing` method it is possible to easily let the built object provide one or more interfaces.

Example:

``` python
  create(Builder('folder').providing(IFoo, IBar))
```
