### PR TITLE
Reindex object security after setting local roles for a principal.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
+- Reindex object security after setting local roles for a principal.
+  [mathias.leimgruber]
+
 - Support "on" keyword argument for with_roles method in group builder.
   [mathias.leimgruber]
 

--- a/ftw/builder/group.py
+++ b/ftw/builder/group.py
@@ -81,6 +81,7 @@ class GroupBuilder(object):
     def set_roles(self, groupid):
         for context, roles in self.local_roles.items():
             context.manage_setLocalRoles(groupid, tuple(roles))
+            context.reindexObjectSecurity()
 
 
 builder_registry.register('group', GroupBuilder)

--- a/ftw/builder/user.py
+++ b/ftw/builder/user.py
@@ -1,10 +1,10 @@
-from Products.CMFCore.utils import getToolByName
 from ftw.builder import builder_registry
+from ftw.builder.utils import strip_diacricits
 from plone.i18n.normalizer.interfaces import IIDNormalizer
+from Products.CMFCore.utils import getToolByName
 from zope.component import getUtility
 from zope.component.hooks import getSite
 import transaction
-from ftw.builder.utils import strip_diacricits
 
 import pkg_resources
 try:
@@ -56,7 +56,10 @@ class UserBuilder(object):
 
     def create(self):
         self.before_create()
-        user = self.create_user(self.userid, self.password, self.roles, self.properties)
+        user = self.create_user(self.userid,
+                                self.password,
+                                self.roles,
+                                self.properties)
         self.after_create(user)
         return user
 
@@ -64,7 +67,7 @@ class UserBuilder(object):
         regtool = getToolByName(self.portal, 'portal_registration')
         mtool = getToolByName(self.portal, 'portal_membership')
         user = regtool.addMember(userid, password, (), properties=properties)
-        self.set_roles(userid, roles)
+        self.set_roles(user.getId(), roles)
         return mtool.getMemberById(userid)
 
     def set_roles(self, userid, roles):
@@ -73,6 +76,7 @@ class UserBuilder(object):
 
         for context, roles in self.local_roles.items():
             context.manage_setLocalRoles(userid, tuple(roles))
+            context.reindexObjectSecurity()
 
     def before_create(self):
         self.update_properties()


### PR DESCRIPTION
This PR adds a context.reindexObjectSecurity after adding local roles (user, group builder `with_roles` method).
