### PR TITLE
DxBuilder: Fix check if field is present (to determine if default values should be set).

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.3.3 (unreleased)
 ------------------
 
+- DxBuilder: Fix check if field is present (to determine if default values should be set).
+  [lgraf]
+
 - DxBuilder: Make sure default values are set before adding content to container.
   [lgraf]
 

--- a/ftw/builder/dexterity.py
+++ b/ftw/builder/dexterity.py
@@ -74,8 +74,14 @@ class DexterityBuilder(PloneObjectBuilder):
             if field.required:
                 continue
 
-            if field.get(field.interface(obj)):
-                continue
+            try:
+                value = field.get(field.interface(obj))
+                if value:
+                    # Field is present, nothing to do
+                    continue
+            except AttributeError:
+                # Field is missing, go on and set default value
+                pass
 
             if name in self.arguments:
                 continue


### PR DESCRIPTION
`field.get()` _will_ raise an `AttributeError` if the field doesn't exist on obj, and
can't be provided with a default value.
