### PR TITLE
DxBuilder: Fix discriminators for default value adapter lookup.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.3.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- DxBuilder: Fixed discriminators for default value adapter lookup.
+  [lgraf]
 
 
 1.3.3 (2014-06-05)

--- a/ftw/builder/dexterity.py
+++ b/ftw/builder/dexterity.py
@@ -36,12 +36,12 @@ class DexterityBuilder(PloneObjectBuilder):
         return obj
 
     def create_object(self):
-        self.insert_field_default_values()
         content = createContent(self.portal_type, **self.arguments)
 
         # Acquisition wrap content temporarily to make sure schema
         # interfaces can be adapted to `content`
         content = content.__of__(self.container)
+        self.insert_field_default_values(content)
         self.set_field_values(content)
         self.set_missing_values_for_empty_fields(content)
         # Remove temporary acquisition wrapper
@@ -54,12 +54,12 @@ class DexterityBuilder(PloneObjectBuilder):
 
         return obj
 
-    def insert_field_default_values(self):
+    def insert_field_default_values(self, obj):
         for name, field in self.iter_fields():
             if name in self.arguments:
                 continue
 
-            default = self.get_default_value_for_field(field)
+            default = self.get_default_value_for_field(obj, field)
             if default:
                 self.arguments[name] = default
 
@@ -90,9 +90,9 @@ class DexterityBuilder(PloneObjectBuilder):
             if missing_value != none_marker:
                 field.set(field.interface(obj), missing_value)
 
-    def get_default_value_for_field(self, field):
+    def get_default_value_for_field(self, obj, field):
         default = queryMultiAdapter(
-            (self.container, self.container.REQUEST, None, field, None),
+            (obj, obj.REQUEST, None, field, None),
             IValue, name='default')
 
         if default is not None:


### PR DESCRIPTION
The adapter lookup for the default value adapter in [`dexterity.py:95`](https://github.com/4teamwork/ftw.builder/blob/5fabb899d8a4c60402994a69f27abb5e35a690a4/ftw/builder/dexterity.py#L95) uses the wrong
discriminators. It should be `(context, request, view, field, widget)`
(see [`plone.directives.form.value.py:32`](https://github.com/plone/plone.directives.form/blob/master/plone/directives/form/value.py#L32)), but instead the lookup currently uses `self.container` as the `context`, which causes default value adapters that use the context as a discriminator to be skipped.

This PR fixes this by supplying the newly created object to the
`insert_field_default_values` and `get_default_value_for_field` methods.

In order to do that, the call to `insert_field_default_values` had to be moved down _after_ the `createContentInContainer` call. This means the default values won't be passed in `**self.arguments` to `createContentInContainer` any more, but instead be set later in the `set_field_values()` call.

/cc @jone @maethu @phgross 
