### PR TITLE
DxBuilder: Fix encoding problem when filling default value for "owners" field

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.3.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- DxBuilder: Fix encoding problem when filling default value for "owners" field.
+  [jone]
 
 
 1.3.3 (2014-06-05)
@@ -17,7 +18,7 @@ Changelog
 - DxBuilder: Make sure default values are set before adding content to container.
   [lgraf]
 
- 
+
 1.3.2 (2014-05-29)
 ------------------
 

--- a/ftw/builder/dexterity.py
+++ b/ftw/builder/dexterity.py
@@ -1,5 +1,7 @@
 from Acquisition import aq_base
 from ftw.builder.builder import PloneObjectBuilder
+from operator import methodcaller
+from plone.app.dexterity.behaviors.metadata import IOwnership
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.dexterity.utils import addContentToContainer
 from plone.dexterity.utils import createContent
@@ -96,8 +98,15 @@ class DexterityBuilder(PloneObjectBuilder):
             IValue, name='default')
 
         if default is not None:
-            return default.get()
-        return getattr(field, 'default', None)
+            value =  default.get()
+        else:
+            value = getattr(field, 'default', None)
+
+        # The default value of the 'creators' field returns a tuple
+        # of strings instead of a tuple of unicodes.
+        if IOwnership['creators'] == field:
+            value = tuple(map(methodcaller('decode', 'utf8'), value))
+        return value
 
     def get_missing_value_for_field(self, field):
         try:

--- a/ftw/builder/tests/test_dexterity.py
+++ b/ftw/builder/tests/test_dexterity.py
@@ -7,6 +7,8 @@ from ftw.builder.dexterity import DexterityBuilder
 from ftw.builder.testing import BUILDER_INTEGRATION_TESTING
 from plone.app.testing import login
 from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.fti import DexterityFTI
 from unittest2 import TestCase
@@ -14,8 +16,8 @@ from zope import schema
 from zope.component import adapter
 from zope.component.globalregistry import getGlobalSiteManager
 from zope.component.hooks import getSite
-from zope.interface import Interface
 from zope.interface import alsoProvides
+from zope.interface import Interface
 from zope.lifecycleevent.interfaces import IObjectAddedEvent
 from zope.lifecycleevent.interfaces import IObjectCreatedEvent
 
@@ -38,7 +40,7 @@ class IBookSchema(Interface):
     author = schema.TextLine(
         title=u'Author',
         required=False,
-        default=u'hugo.boss')
+        default=u'test_user_1_')
 
 
 alsoProvides(IBookSchema, IFormFieldProvider)
@@ -56,11 +58,8 @@ class DexterityBaseTestCase(TestCase):
         super(DexterityBaseTestCase, self).setUp()
         self.portal = self.layer['portal']
 
-        # create test user
-        pas = self.portal['acl_users']
-        pas.source_users.addUser(u'hugo.boss', u'Hugo Boss', 'secret')
-        setRoles(self.portal, u'hugo.boss', ['Manager'])
-        login(self.portal, u'Hugo Boss')
+        setRoles(self.portal, TEST_USER_ID, ['Contributor'])
+        login(self.portal, TEST_USER_NAME)
 
         # add test fti
         self.fti = DexterityFTI('Book')
@@ -121,8 +120,8 @@ class TestDexterityBuilder(DexterityBaseTestCase):
         book = create(Builder('book')
                      .having(title=u'Testtitle'))
 
-        self.assertEquals(u'hugo.boss', book.author)
-        self.assertEquals((u'hugo.boss', ), book.listCreators())
+        self.assertEquals(u'test_user_1_', book.author)
+        self.assertEquals((u'test_user_1_', ), book.listCreators())
 
     def test_object_providing_interface(self):
         book = create(Builder('book').providing(IFoo))


### PR DESCRIPTION
Fixes #23 

The default value adapter for the `IOwnership.owners` field returns a tuple of byte strings, but unicodes are required.

Although it is not correct it is not a problem in the "real" world, since the default value adapter is used for filling the form field, which is converted to unicodes correctly when submitted.
Therefore I decided to do a hack which fixes this issue for exactly this field. I've not done it in a more generic way because our custom fields should have better default value adapters which use unicodes.

@elioschmutz @deiferni this fixes the issues you've had with

```
WrongContainedType: ([WrongType('test_user_1_', <type 'unicode'>, '')], 'creators')
```
