### PR TITLE
DxBuilder: Only determine default values *after* object has been added to container.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.3.4 (unreleased)
 ------------------
 
+- DxBuilder: Only determine default values *after* object has been added to container.
+  [lgraf]
+
 - DxBuilder: Fixed discriminators for default value adapter lookup.
   [lgraf]
 

--- a/ftw/builder/dexterity.py
+++ b/ftw/builder/dexterity.py
@@ -41,7 +41,6 @@ class DexterityBuilder(PloneObjectBuilder):
         # Acquisition wrap content temporarily to make sure schema
         # interfaces can be adapted to `content`
         content = content.__of__(self.container)
-        self.insert_field_default_values(content)
         self.set_field_values(content)
         self.set_missing_values_for_empty_fields(content)
         # Remove temporary acquisition wrapper
@@ -51,6 +50,9 @@ class DexterityBuilder(PloneObjectBuilder):
             self.container,
             content,
             checkConstraints=self.checkConstraints)
+
+        self.insert_field_default_values(obj)
+        self.set_field_values(obj)
 
         return obj
 


### PR DESCRIPTION
This solves an issue with IntID generation for objects. I have no idea why this works, but it seems to resolve our current test failures.

/cc @phgross @maethu @jone  
