### PR TITLE
Fixed default value getter for "owners" field not from the plone default...

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed default value setter for different "owners" field.
+  [phgross]
 
 
 1.3.4 (2014-08-29)

--- a/ftw/builder/dexterity.py
+++ b/ftw/builder/dexterity.py
@@ -104,7 +104,10 @@ class DexterityBuilder(PloneObjectBuilder):
 
         # The default value of the 'creators' field returns a tuple
         # of strings instead of a tuple of unicodes.
-        if IOwnership['creators'] == field:
+        # -----
+        # Because the field equality check is insufficient we need to check
+        # the field interface additionally.
+        if IOwnership['creators'] == field and field.interface == IOwnership:
             value = tuple(map(methodcaller('decode', 'utf8'), value))
         return value
 


### PR DESCRIPTION
This is a follow up from PR #27.

Because the equality check for fields in [`zope.schema`](https://github.com/zopefoundation/zope.schema/blob/978f020ddc8b8be57cddca57e7c95df42411d7cf/src/zope/schema/_bootstrapfields.py#L187) is insufficient, some special check for the `IOwnership.creators` fix from the PR #27 is needed.

Because a different tuple field with the name `creators` (for example in [opengever.core](https://github.com/4teamwork/opengever.core/blob/master/opengever/base/behaviors/creator.py#L19) is handled as the `IOwnership.creators` field, because the `field.interface` is not compared in the equality check. See the following debugging output:

```
(Pdb) field.interface
<InterfaceClass opengever.base.behaviors.creator.ICreator>
(Pdb) field
<zope.schema._field.Tuple object at 0x106f9b590>
(Pdb) IOwnership['creators']
<zope.schema._field.Tuple object at 0x10698e150>
(Pdb) IOwnership['creators'].interface
<InterfaceClass plone.app.dexterity.behaviors.metadata.IOwnership>
(Pdb) field == IOwnership['creators']
True
```

@jone, @deiferni 
