### PR TITLE
Fix DX effective date test for Plone 4.3.4.

### DIFF
--- a/ftw/builder/tests/test_dexterity.py
+++ b/ftw/builder/tests/test_dexterity.py
@@ -1,4 +1,3 @@
-from DateTime import DateTime
 from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
@@ -108,7 +107,7 @@ class TestDexterityBuilder(DexterityBaseTestCase):
                       .having(title=u'Testtitle',
                               effective=datetime(2013, 1, 1)))
 
-        self.assertEquals(DateTime(2013, 1, 1), book.effective())
+        self.assertEquals(datetime(2013, 1, 1), book.effective)
 
     def test_initalizing_fields_with_missing_value(self):
         book = create(Builder('book')


### PR DESCRIPTION
This fixes the [current test failure](https://jenkins.4teamwork.ch/job/ftw.builder-master-test-plone-4.3.x.cfg/537/console) for Plone 4.3.4.1.

`obj.effective` now seems to be not callable any more (again), and is a `datetime.datetime` instead of `DateTime`. Didn't look into it any further, but this fixes the test for the current Plone version.

@jone @phgross 
