### PR TITLE
Possibly restore Plone 4.1 compatibility

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.5.0 (unreleased)
 ------------------
 
+- Restore Plone 4.1 compatibility by making any DX imports conditional.
+  [lgraf]
+
 - Plone 5 support: default content builders are switched to the dexterity implementation
   by default for Plone >= 5.
   The builder classes were moved from ``archetypes`` module to ``content`` module.

--- a/ftw/builder/__init__.py
+++ b/ftw/builder/__init__.py
@@ -1,3 +1,12 @@
+import pkg_resources
+
+try:
+    pkg_resources.get_distribution('plone.dexterity')
+except pkg_resources.DistributionNotFound:
+    HAS_DEXTERITY = False
+else:
+    HAS_DEXTERITY = True
+
 from ftw.builder.registry import builder_registry
 
 from ftw.builder.builder import Builder

--- a/ftw/builder/content.py
+++ b/ftw/builder/content.py
@@ -1,10 +1,12 @@
 from ftw.builder import builder_registry
+from ftw.builder import HAS_DEXTERITY
 from ftw.builder.archetypes import ArchetypesBuilder
-from ftw.builder.dexterity import DexterityBuilder
-from plone.namedfile.file import NamedBlobFile
 from Products.CMFPlone.utils import getFSVersionTuple
 from StringIO import StringIO
 
+if HAS_DEXTERITY:
+    from ftw.builder.dexterity import DexterityBuilder
+    from plone.namedfile.file import NamedBlobFile
 
 if getFSVersionTuple() > (5, ):
     DefaultContentBuilder = DexterityBuilder
@@ -32,7 +34,7 @@ class FileBuilder(DefaultContentBuilder):
     portal_type = 'File'
 
     def attach_file_containing(self, content, name=u"test.doc"):
-        if issubclass(self.__class__, DexterityBuilder):
+        if HAS_DEXTERITY and issubclass(self.__class__, DexterityBuilder):
             return self._attach_dx_file(content, name)
         else:
             return self._attach_at_file(content, name)

--- a/ftw/builder/tests/test_content.py
+++ b/ftw/builder/tests/test_content.py
@@ -1,11 +1,14 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.builder import HAS_DEXTERITY
 from ftw.builder.tests import IntegrationTestCase
 from operator import methodcaller
-from plone.dexterity.interfaces import IDexterityContent
-from plone.rfc822.interfaces import IPrimaryFieldInfo
 from Products.CMFCore.utils import getToolByName
 from zope.interface import Interface
+
+if HAS_DEXTERITY:
+    from plone.dexterity.interfaces import IDexterityContent
+    from plone.rfc822.interfaces import IPrimaryFieldInfo
 
 
 class IFoo(Interface):
@@ -13,7 +16,7 @@ class IFoo(Interface):
 
 
 def get_file(obj):
-    if IDexterityContent.providedBy(obj):
+    if HAS_DEXTERITY and IDexterityContent.providedBy(obj):
         return IPrimaryFieldInfo(obj).value
     else:
         return obj.getFile()


### PR DESCRIPTION
Currently `ftw.builder` is still used by some packages that offer Plone 4.1 compatibility ([`ftw.contentpage`](https://jenkins.4teamwork.ch/job/ftw.contentpage-master-test-plone-4.1.x.cfg/1052/) and [`ftw.contenttemplates`](https://jenkins.4teamwork.ch/job/ftw.contenttemplates-master-test-plone-4.1.x.cfg/834/)) to name just two).

Because the recent change from #32 now [unconditionally imports the Dexterity builders](https://github.com/4teamwork/ftw.builder/commit/680d2f60662359569ef62e0eaf78dd8b7cb37a0b), `ftw.builder` will fail on Plone 4.1 because Dexterity isn't shipped by default up until Plone 4.2.

We have a couple options here:
- Drop 4.1 support in those packages
- Restore 4.1 compatibility in `ftw.builder` by either
  - making all Dexterity imports conditional on the Plone version (or the [availability of `plone.dexterity`](http://docs.plone.org/external/plone.api/docs/contribute/conventions.html#about-imports)). This currently would require defining a `HAS_DEXTERITY` somewhere, and making the [imports in `content.py`](https://github.com/4teamwork/ftw.builder/blob/master/ftw/builder/content.py#L3-4) and [`test_content.py`](https://github.com/4teamwork/ftw.builder/blob/master/ftw/builder/tests/test_content.py#L5) conditional
  - or adding `plone.app.dexterity` to `ftw.builder`'s requirements in `setup.py` and extending from the [old-style Dexterity KGS](http://docs.plone.org/external/plone.app.dexterity/docs/install.html#installing-dexterity-on-older-versions-of-plone) in `test-plone.4.1.x.cfg`. This would also require the [`test-plone-4.1.x.cfg` from `ftw-buildouts`](https://github.com/4teamwork/ftw-buildouts/blob/master/test-plone-4.1.x.cfg) to extend from the DX KGS though, not sure what the implications of that would be.

@jone @maethu @phgross @deiferni 

What do you think?
