### PR TITLE
Fix NamedBlobFile import issue for Plone <= 4.2 where blobs are optional

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix NamedBlobFile import issue for Plone <= 4.2 where blobs are optional.
+  [jone]
 
 
 1.5.0 (2014-12-03)

--- a/ftw/builder/content.py
+++ b/ftw/builder/content.py
@@ -6,7 +6,13 @@ from StringIO import StringIO
 
 if HAS_DEXTERITY:
     from ftw.builder.dexterity import DexterityBuilder
-    from plone.namedfile.file import NamedBlobFile
+
+    from plone.namedfile.interfaces import HAVE_BLOBS
+    if HAVE_BLOBS:
+        from plone.namedfile.file import NamedBlobFile as NamedFile
+    else:
+        from plone.namedfile.file import NamedFile
+
 
 if getFSVersionTuple() > (5, ):
     DefaultContentBuilder = DexterityBuilder
@@ -54,7 +60,7 @@ class FileBuilder(DefaultContentBuilder):
         return self
 
     def _attach_dx_file(self, content, name):
-        self.attach(NamedBlobFile(data=content, filename=name))
+        self.attach(NamedFile(data=content, filename=name))
         return self
 
 builder_registry.register('file', FileBuilder)


### PR DESCRIPTION
In Plone <= 4.2 blobs are optional, but in Plone >= 4.3 blobs are standard.
This fixes issues for installations where blobs are not installed on older versions.

As discussed in #34 
