### PR TITLE
File builder: fix default filename encoding for AT.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 1.5.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- File builder: fix default filename encoding for AT.
+  This was a regression in 1.5.0, where filenames were changed to unicode
+  because of the consolidation of Archetypes and Dexterity builders.
+  [jone]
 
 
 1.5.1 (2014-12-03)

--- a/ftw/builder/content.py
+++ b/ftw/builder/content.py
@@ -43,6 +43,8 @@ class FileBuilder(DefaultContentBuilder):
         if HAS_DEXTERITY and issubclass(self.__class__, DexterityBuilder):
             return self._attach_dx_file(content, name)
         else:
+            if isinstance(name, unicode):
+                name = name.encode('utf-8')
             return self._attach_at_file(content, name)
 
     def attach(self, file_):


### PR DESCRIPTION
This was a regression in 1.5.0, where filenames were changed to unicode
because of the consolidation of Archetypes and Dexterity builders.
