### PR TITLE
Package builder: fix importing packages with shared namespace.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 1.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Package builder: fix importing packages with shared namespace.
+  When building a package in an already imported namespace package,
+  the namespace package must be refreshed by deleting it before importing.
+  [jone]
 
 
 1.6.0 (2014-12-31)

--- a/ftw/builder/package.py
+++ b/ftw/builder/package.py
@@ -87,6 +87,9 @@ class Package(object):
         context manager (with statement), otherwise it may raise
         an ``ImportError``.
         """
+        for name in parent_namespaces(self.name):
+            if name in sys.modules:
+                del sys.modules[name]
         return __import__(self.name, fromlist=self.name)
 
     @contextmanager

--- a/ftw/builder/tests/test_package_builder.py
+++ b/ftw/builder/tests/test_package_builder.py
@@ -116,6 +116,14 @@ class TestPackageBuilder(TestCase):
     # for each test and the module will not be imported but taken from sys.modules.
     test_package_path_is_cleaned_up = test_package_can_be_imported
 
+    def test_importing_package_with_shared_namespace_works(self):
+        package = create(Builder('python package')
+                         .named('ftw.testpackage')
+                         .at_path(self.layer['temp_directory']))
+        with package:
+            module = package.import_package()
+            self.assertTrue(inspect.ismodule(module))
+
     def test_context_manager_returns_package_repr(self):
         package = create(Builder('python package')
                          .named('the.package')


### PR DESCRIPTION
When building a package in an already imported namespace package,
the namespace package must be refreshed by deleting it before importing.