### PR TITLE
Add creation date setter for PloneObject builders.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add creation date setter to builder.
+  [mbaechtold]
 
 
 1.6.0 (2014-12-31)

--- a/ftw/builder/builder.py
+++ b/ftw/builder/builder.py
@@ -28,6 +28,7 @@ class PloneObjectBuilder(object):
         self.arguments = {}
         self.review_state = None
         self.modification_date = None
+        self.creation_date = None
         self.interfaces = []
 
     def within(self, container):
@@ -48,6 +49,10 @@ class PloneObjectBuilder(object):
 
     def with_modification_date(self, modification_date):
         self.modification_date = modification_date
+        return self
+
+    def with_creation_date(self, creation_date):
+        self.creation_date = creation_date
         return self
 
     def providing(self, *interfaces):
@@ -73,6 +78,9 @@ class PloneObjectBuilder(object):
         if self.modification_date:
             self.set_modification_date(obj)
 
+        if self.creation_date:
+            self.set_creation_date(obj)
+
         if self.session.auto_commit:
             transaction.commit()
 
@@ -89,9 +97,9 @@ class PloneObjectBuilder(object):
                     self.portal_type, chain))
 
         wftool.setStatusOf(chain[0], obj, {
-                'review_state': self.review_state,
-                'action': '',
-                'actor': ''})
+            'review_state': self.review_state,
+            'action': '',
+            'actor': ''})
 
         for workflow_id in chain:
             workflow = wftool.get(workflow_id)
@@ -105,3 +113,7 @@ class PloneObjectBuilder(object):
         obj.setModificationDate(
             modification_date=self.modification_date)
         obj.reindexObject(idxs=['modified'])
+
+    def set_creation_date(self, obj):
+        obj.setCreationDate(creation_date=self.creation_date)
+        obj.reindexObject(idxs=['created'])

--- a/ftw/builder/dexterity.py
+++ b/ftw/builder/dexterity.py
@@ -98,7 +98,7 @@ class DexterityBuilder(PloneObjectBuilder):
             IValue, name='default')
 
         if default is not None:
-            value =  default.get()
+            value = default.get()
         else:
             value = getattr(field, 'default', None)
 
@@ -135,3 +135,7 @@ class DexterityBuilder(PloneObjectBuilder):
         yield fti.lookupSchema()
         for schema in getAdditionalSchemata(portal_type=portal_type):
             yield schema
+
+    def set_creation_date(self, obj):
+        obj.creation_date = self.creation_date
+        obj.reindexObject(idxs=['created'])

--- a/ftw/builder/tests/test_builder.py
+++ b/ftw/builder/tests/test_builder.py
@@ -83,6 +83,15 @@ class TestCreatingObjects(IntegrationTestCase):
         self.assertEquals(modified, folder.modified())
         self.assertEquals(modified, obj2brain(folder).modified)
 
+    def test_with_creation_date_updates_obj_and_brain(self):
+        created = DateTime(2011, 2, 3, 5, 7, 11)
+
+        folder = create(Builder('folder')
+                        .with_creation_date(created))
+
+        self.assertEquals(created, folder.created())
+        self.assertEquals(created, obj2brain(folder).created)
+
     def set_workflow_chain(self, for_type, to_workflow):
         wftool = getToolByName(self.portal, 'portal_workflow')
         wftool.setChainForPortalTypes((for_type,),

--- a/ftw/builder/tests/test_dexterity.py
+++ b/ftw/builder/tests/test_dexterity.py
@@ -5,6 +5,7 @@ from ftw.builder import create
 from ftw.builder import registry
 from ftw.builder.dexterity import DexterityBuilder
 from ftw.builder.testing import BUILDER_INTEGRATION_TESTING
+from ftw.builder.tests.test_builder import obj2brain
 from plone.app.testing import login
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
@@ -126,6 +127,14 @@ class TestDexterityBuilder(DexterityBaseTestCase):
     def test_object_providing_interface(self):
         book = create(Builder('book').providing(IFoo))
         self.assertTrue(IFoo.providedBy(book))
+
+    def test_with_creation_date_updates_obj_and_brain(self):
+        creation_date = DateTime(2011, 2, 3, 5, 7, 11)
+
+        book = create(Builder('book').with_creation_date(creation_date))
+
+        self.assertEquals(creation_date, book.created())
+        self.assertEquals(creation_date, obj2brain(book).created)
 
 
 @adapter(IObjectCreatedEvent)


### PR DESCRIPTION
This is useful if you need to compare your test objects including the creation date. Without setting the creation date manually, the date would be different in each run.

/cc @phgross 