### PR TITLE
package builder: update pkg_resources working set when loading package.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,12 @@ Changelog
 1.6.1 (unreleased)
 ------------------
 
+- Package builder: update pkg_resources working set when loading package.
+  [jone]
+
+-
+  [jone]
+
 - Add creation date setter to builder.
   [mbaechtold]
 

--- a/ftw/builder/package.py
+++ b/ftw/builder/package.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from copy import deepcopy
 from ftw.builder import Builder
 from ftw.builder import builder_registry
 from ftw.builder import create
@@ -6,6 +7,7 @@ from ftw.builder.utils import parent_namespaces
 from path import Path
 from zope.configuration import xmlconfig
 import imp
+import pkg_resources
 import stat
 import subprocess
 import sys
@@ -70,9 +72,12 @@ class Package(object):
 
     def __enter__(self):
         sys.path.insert(0, self.root_path)
+        self._original_working_set = pkg_resources.working_set
+        pkg_resources.working_set = pkg_resources.WorkingSet._build_master()
         return self
 
     def __exit__(self, type, value, tb):
+        pkg_resources.working_set = self._original_working_set
         sys.path.remove(self.root_path)
         modules_to_remove = filter(lambda name: name.startswith(self.name),
                                    sys.modules)

--- a/ftw/builder/tests/test_package_builder.py
+++ b/ftw/builder/tests/test_package_builder.py
@@ -4,6 +4,7 @@ from ftw.builder.testing import TEMP_DIRECTORY_LAYER
 from path import Path
 from unittest2 import TestCase
 import inspect
+import pkg_resources
 
 
 class TestPackageBuilder(TestCase):
@@ -131,6 +132,19 @@ class TestPackageBuilder(TestCase):
         with package.imported() as module:
             self.assertTrue(inspect.ismodule(module))
             self.assertEqual(path.joinpath('the', 'package'), Path(module.__file__).dirname())
+
+    def test_pkg_resources_working_set_is_updated(self):
+        path = self.layer['temp_directory'].joinpath('the.package')
+        package = create(Builder('python package').named('the.package').at_path(path))
+
+        with self.assertRaises(pkg_resources.DistributionNotFound):
+            pkg_resources.get_distribution('the.package')
+
+        with package.imported():
+            self.assertTrue(pkg_resources.get_distribution('the.package'))
+
+        with self.assertRaises(pkg_resources.DistributionNotFound):
+            pkg_resources.get_distribution('the.package')
 
     def test_create_a_directory_in_the_root(self):
         path = self.layer['temp_directory'].joinpath('the.package')


### PR DESCRIPTION
Rebuilding the working set allows to find the distribution which of the package
built with the package builder.
When leaving the "loaded" package context manager, the working set is reset to
the original state.

This allows us to do things like pkg_resources.get_distribution while the package
is loaded.