### PR TITLE
Package builder: make package version configurable.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -15,9 +15,6 @@ Changelog
 - Package builder: update pkg_resources working set when loading package.
   [jone]
 
--
-  [jone]
-
 - Add creation date setter to builder.
   [mbaechtold]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Package builder: make package version configurable.
+  [jone]
 
 
 1.6.1 (2015-05-20)

--- a/ftw/builder/package.py
+++ b/ftw/builder/package.py
@@ -17,7 +17,7 @@ SETUP_PY_TEMPLATE = """
 from setuptools import setup, find_packages
 
 setup(name='{name}',
-      version='1.0.0.dev0',
+      version='{version}',
       packages=find_packages(exclude=['ez_setup']),
       namespace_packages={namespaces},
       include_package_data=True,
@@ -131,6 +131,7 @@ class PythonPackageBuilder(object):
         self.session = session
         self.path = None
         self.name = None
+        self.version = '1.0.0.dev0'
         self.namespaces = None
         self.package = Builder('subpackage')
         self.directories = []
@@ -152,6 +153,12 @@ class PythonPackageBuilder(object):
         self._validate_package_name(name)
         self.name = name
         self.package.with_i18n_domain(name)
+        return self
+
+    def with_version(self, version):
+        """Change the package version.
+        """
+        self.version = version
         return self
 
     def with_subpackage(self, subpackage_builder):
@@ -245,6 +252,7 @@ class PythonPackageBuilder(object):
     def _create_setup(self):
         self.with_root_file('setup.py', SETUP_PY_TEMPLATE.format(
                 name=self.name,
+                version=self.version,
                 namespaces=parent_namespaces(self.name)))
 
     def _create_namespaces(self):

--- a/ftw/builder/tests/test_package_builder.py
+++ b/ftw/builder/tests/test_package_builder.py
@@ -208,6 +208,20 @@ class TestPackageBuilder(TestCase):
         self.assertIn('<browser:page name="hello-world"/>',
                       package.package_path.joinpath('configure.zcml').text())
 
+    def test_package_version(self):
+        with create(Builder('python package')
+                    .named('the.package')
+                    .at_path(self.layer['temp_directory'])).imported():
+            self.assertEquals('1.0.0.dev0',
+                              pkg_resources.get_distribution('the.package').version)
+
+        with create(Builder('python package')
+                    .named('the.package')
+                    .with_version('1.2.3')
+                    .at_path(self.layer['temp_directory'])).imported():
+            self.assertEquals('1.2.3',
+                              pkg_resources.get_distribution('the.package').version)
+
 
 class TestNamespacePackage(TestCase):
     layer = TEMP_DIRECTORY_LAYER


### PR DESCRIPTION
By using .with_version('1.2.3') on the package builder, the package version can easily be changed.