### PR TITLE
 Automatically create relation-values from plone content-types.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.6.4 (unreleased)
 ------------------
 
+- Automatically create relation-values from plone content-types while setting field-values.
+  [deiferni]
+
 - Add support for building portlets.
   [mbaechtold]
 

--- a/ftw/builder/testing.py
+++ b/ftw/builder/testing.py
@@ -83,6 +83,9 @@ class BuilderTestingLayer(PloneSandboxLayer):
     def setUpPloneSite(self, portal):
         if getFSVersionTuple() > (5, ):
             applyProfile(portal, 'plone.app.contenttypes:default')
+        else:
+            applyProfile(portal, 'plone.app.dexterity:default')
+            applyProfile(portal, 'plone.app.relationfield:default')
 
 
 BUILDER_FIXTURE = BuilderTestingLayer()

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,9 @@ tests_require = [
     'Acquisition',
     'ftw.testbrowser',
     'plone.api',
+    'plone.app.dexterity[relations]',
     'plone.app.testing',
+    'plone.formwidget.contenttree',
     'unittest2',
     'zope.configuration',
     ]


### PR DESCRIPTION
This PR improves dexterity content-creation when using relation-fields from [plone.app.relationfield](https://github.com/plone/plone.app.relationfield).

It is now possible to pass plone content-type instances as field-values for relation-fields when building, e.g.:

```python
    book = create(Builder('book').having(relation_list=[related]))
    # or
    book = create(Builder('book').having(relation_choice=related))
```

This improves the old behaviour where `RelationValue` instances would have to be created manually.

```python
    book = create(Builder('book').having(relation_choice=RelationValue(intids.getId(related))))
```

The changes are backwards-compatible and also work with `RelationValue` instances as parameters.