### PR TITLE
add conditional import for z3c.relationfield.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add conditional import for Relationvalues since we don't always have z3c.relation.
+  [tschanzt]
 
 
 1.7.0 (2015-08-20)

--- a/ftw/builder/__init__.py
+++ b/ftw/builder/__init__.py
@@ -7,6 +7,13 @@ except pkg_resources.DistributionNotFound:
 else:
     HAS_DEXTERITY = True
 
+try:
+    pkg_resources.get_distribution('z3c.relationfield')
+except pkg_resources.DistributionNotFound:
+    HAS_RELATION = False
+else:
+    HAS_RELATION = True
+
 from ftw.builder.registry import builder_registry
 
 from ftw.builder.builder import Builder

--- a/ftw/builder/dexterity.py
+++ b/ftw/builder/dexterity.py
@@ -1,4 +1,5 @@
 from Acquisition import aq_base
+from ftw.builder import HAS_RELATION
 from ftw.builder.builder import PloneObjectBuilder
 from operator import methodcaller
 from plone.app.dexterity.behaviors.metadata import IOwnership
@@ -8,16 +9,18 @@ from plone.dexterity.utils import createContent
 from plone.dexterity.utils import getAdditionalSchemata
 from plone.dexterity.utils import iterSchemata
 from z3c.form.interfaces import IValue
-from z3c.relationfield.interfaces import IRelationChoice
-from z3c.relationfield.interfaces import IRelationList
-from z3c.relationfield.interfaces import IRelationValue
-from z3c.relationfield.relation import RelationValue
+
 from zope.component import getUtility
 from zope.component import queryMultiAdapter
 from zope.component import queryUtility
-from zope.intid.interfaces import IIntIds
 from zope.schema import getFieldsInOrder
 
+if HAS_RELATION:
+    from z3c.relationfield.interfaces import IRelationChoice
+    from z3c.relationfield.interfaces import IRelationList
+    from z3c.relationfield.interfaces import IRelationValue
+    from z3c.relationfield.relation import RelationValue
+    from zope.intid.interfaces import IIntIds
 
 none_marker = object()
 
@@ -76,9 +79,9 @@ class DexterityBuilder(PloneObjectBuilder):
             if name in self.arguments:
                 value = self.arguments.get(name)
 
-                if IRelationChoice.providedBy(field):
+                if HAS_RELATION and IRelationChoice.providedBy(field):
                     value = self._as_relation_value(value)
-                elif IRelationList.providedBy(field):
+                elif HAS_RELATION and IRelationList.providedBy(field):
                     value = [self._as_relation_value(item) for item in value]
 
                 field.set(field.interface(obj), value)


### PR DESCRIPTION
@jone @deiferni I added conditional imports for the z3c.relationfield specific stuff and added checks at the if statements affected. This is necessary since Plone 4.3.6(maybe some older versions too) require plone.app.dexterity but don't install the relations extra. 