### PR TITLE
DX-Builder: Initialize attributes only with set_field_values.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 1.7.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- DX-Builder: Initialize attributes only with set_field_values.
+  No longer pass all arguments to createContent to avoid setting fields that
+  are stored in annotations as attributes as well.
+  [deiferni]
 
 
 1.7.1 (2015-08-20)

--- a/ftw/builder/testing.py
+++ b/ftw/builder/testing.py
@@ -80,6 +80,21 @@ class BuilderTestingLayer(PloneSandboxLayer):
             '</configure>',
             context=configurationContext)
 
+        # register behavior
+        xmlconfig.string(
+            '<configure xmlns="http://namespaces.zope.org/zope"'
+            '           xmlns:plone="http://namespaces.plone.org/plone">'
+            '    <include package="zope.component" file="meta.zcml" />'
+            '    <include package="plone.behavior" file="meta.zcml" />'
+            '    <include package="zope.annotation" />'
+            '    <plone:behavior'
+            '        title="Annotation behavior"'
+            '        provides="ftw.builder.tests.test_dexterity.IAnnotationStored"'
+            '        factory="plone.behavior.AnnotationStorage"'
+            '    />'
+            '</configure>',
+            context=configurationContext)
+
     def setUpPloneSite(self, portal):
         if getFSVersionTuple() > (5, ):
             applyProfile(portal, 'plone.app.contenttypes:default')


### PR DESCRIPTION
This PR fixes an issue with field initialization from a builders arguments as set by `having` or similar methods.

When creating dexterity content the builder passes all arguments to `createContent` in addition to setting them with `set_field_values`. This is problematic for annotation-storage fields since the field is set as attribute on the created object as well. This will lead do unpickleable content in some cases, e.g. when setting relations.

This PR fixes that problem by no longer passing all arguments to `createContent` but only 'id' and 'title'. Unfortunately this causes further problems with plone because an `IObjectCreatedEvent` is fired by `createContent`, after which plone or our packages may expect the content object to have its fields initialized. This issue is adressed by implementing our own `_create_content` method which does not fire an `IObjectCreatedEvent`, firing the event is deferred until after all fields and defaults have been set by the builder.

*(This issue seems to have been adressed in 'createContent' of newer `plone.dexterity` versions, but is not yet fixed as of version `2.1.3`)*