### PR TITLE
UserBuilder: add method to create a user within specified groups.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.7.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- UserBuilder: add method to create a user within specified groups.
+  [deiferni]
 
 
 1.7.2 (2015-09-30)

--- a/ftw/builder/tests/test_users.py
+++ b/ftw/builder/tests/test_users.py
@@ -28,6 +28,15 @@ class TestUserBuilder(IntegrationTestCase):
              'fullname': user.getProperty('fullname'),
              'email': user.getProperty('email')})
 
+    def test_user_can_be_created_in_groups(self):
+        create(Builder('group').with_groupid('foo'))
+        create(Builder('group').with_groupid('bar'))
+        create(Builder('user').named('Hans', 'Peter').in_groups('foo', 'bar'))
+
+        portal_groups = getToolByName(self.portal, 'portal_groups')
+        self.assertEqual(['hans.peter'], portal_groups.getGroupMembers('foo'))
+        self.assertEqual(['hans.peter'], portal_groups.getGroupMembers('bar'))
+
     def test_first_and_lastname_are_capitalized(self):
         user = create(Builder('user').named('hans-peter', 'linder'))
         self.assertEquals('Linder Hans-Peter', user.getProperty('fullname'))


### PR DESCRIPTION
Currently it is only possible to add users to a group while creating the group with `GroupBuilder` using its `with_members` method. This PR adds a method to specify a user's groups while building the user.