### PR TITLE
Fix setting values for dexterity-readonly fields.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.7.4 (unreleased)
 ------------------
 
+- Fix setting values for dexterity-readonly fields.
+  [elioschmutz]
+
 - Fix encoding problem when creating AT blobs. [jone]
 
 

--- a/ftw/builder/dexterity.py
+++ b/ftw/builder/dexterity.py
@@ -112,6 +112,7 @@ class DexterityBuilder(PloneObjectBuilder):
 
     def set_field_values(self, obj):
         for name, field in self.iter_fields(obj):
+
             if name in self.arguments:
                 value = self.arguments.get(name)
 
@@ -184,6 +185,9 @@ class DexterityBuilder(PloneObjectBuilder):
 
         for schemata in schematas:
             for name, field in getFieldsInOrder(schemata):
+                if hasattr(field, 'readonly') and field.readonly:
+                    continue
+
                 yield (name, field)
 
     def iter_schemata_for_protal_type(self, portal_type):


### PR DESCRIPTION
@jone 

If the builder gets readonly schema fields, it tries to set them anyway. It will raise an error:

```bash
File "/Users/elioschmutz/projects/ses.web/ses/web/tests/test_contacts.py", line 23, in test_show_edit_link_only_for_editors
    .within(self.contactfolder))
  File "/Users/elioschmutz/Plone/eggs/ftw.builder-1.7.3-py2.7.egg/ftw/builder/builder.py", line 12, in create
    return builder.create(**kwargs)
  File "/Users/elioschmutz/Plone/eggs/ftw.builder-1.7.3-py2.7.egg/ftw/builder/dexterity.py", line 56, in create
    obj = self.create_object()
  File "/Users/elioschmutz/Plone/eggs/ftw.builder-1.7.3-py2.7.egg/ftw/builder/dexterity.py", line 91, in create_object
    self.set_field_values(content)
  File "/Users/elioschmutz/Plone/eggs/ftw.builder-1.7.3-py2.7.egg/ftw/builder/dexterity.py", line 123, in set_field_values
    field.set(field.interface(obj), value)
  File "/Users/elioschmutz/Plone/eggs/zope.schema-4.2.2-py2.7.egg/zope/schema/_bootstrapfields.py", line 226, in set
    object.__class__.__name__))
TypeError: Can't set values on read-only fields (name=language, class=plone.app.dexterity.behaviors.metadata.Categorization)
```

This PR will fix this issue.