### PR TITLE
DX: Bind zope.schema fields when determining default values

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.7.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- DX: Bind zope.schema fields when determining default values in order to
+  have a context (i.e. container) to pass to an IContextAwareDefaultFactory.
+  [lgraf]
 
 
 1.7.4 (2016-03-30)

--- a/ftw/builder/dexterity.py
+++ b/ftw/builder/dexterity.py
@@ -160,7 +160,10 @@ class DexterityBuilder(PloneObjectBuilder):
         if default is not None:
             value = default.get()
         else:
-            value = getattr(field, 'default', None)
+            # Bind field so that for an IContextAwareDefaultFactory it
+            # gets passed a context (i.e. the container)
+            bound_field = field.bind(self.container)
+            value = getattr(bound_field, 'default', None)
 
         # The default value of the 'creators' field returns a tuple
         # of strings instead of a tuple of unicodes.


### PR DESCRIPTION
Bind `zope.schema` fields when determining default values in order to have a **context** (i.e. container) to pass to an `IContextAwareDefaultFactory`.

Otherwise, [`field_instance.context` will be `None`, and context aware default factories will be called with `None`](https://github.com/zopefoundation/zope.schema/blob/master/src/zope/schema/_bootstrapfields.py#L70-L71) as their argument instead of the container.

@deiferni 