### PR TITLE
add ".with_property" method to content builders.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,6 +160,7 @@ setting basic options:
 - ``in_state(review_state)`` - set the object into any review state of the workflow
   configured for this type
 - ``providing(interface1, interface2, ...)`` - let the object provide interfaces
+- ``with_property(name, value, value_type='string')`` - set a property
 
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.8.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add ".with_property" method to content builders. [jone]
 
 
 1.8.1 (2016-06-30)

--- a/ftw/builder/archetypes.py
+++ b/ftw/builder/archetypes.py
@@ -18,6 +18,8 @@ class ArchetypesBuilder(PloneObjectBuilder):
             self.portal_type, name, **self.arguments)
         obj = self.container.get(name)
 
+        self.set_properties(obj)
+
         if processForm:
             obj.processForm()
         return obj

--- a/ftw/builder/builder.py
+++ b/ftw/builder/builder.py
@@ -30,6 +30,7 @@ class PloneObjectBuilder(object):
         self.modification_date = None
         self.creation_date = None
         self.interfaces = []
+        self.properties = []
 
     def within(self, container):
         self.container = container
@@ -53,6 +54,10 @@ class PloneObjectBuilder(object):
 
     def with_creation_date(self, creation_date):
         self.creation_date = creation_date
+        return self
+
+    def with_property(self, name, value, value_type='string'):
+        self.properties.append((name, value, value_type))
         return self
 
     def providing(self, *interfaces):
@@ -83,6 +88,10 @@ class PloneObjectBuilder(object):
 
         if self.session.auto_commit:
             transaction.commit()
+
+    def set_properties(self, obj):
+        for property_args in self.properties:
+            obj._setProperty(*property_args)
 
     def change_workflow_state(self, obj):
         if not self.review_state:

--- a/ftw/builder/dexterity.py
+++ b/ftw/builder/dexterity.py
@@ -90,6 +90,7 @@ class DexterityBuilder(PloneObjectBuilder):
         content = content.__of__(self.container)
         self.set_field_values(content)
         self.set_missing_values_for_empty_fields(content)
+        self.set_properties(content)
         # Remove temporary acquisition wrapper
         content = aq_base(content)
         notify(ObjectCreatedEvent(content))

--- a/ftw/builder/tests/test_archetypes.py
+++ b/ftw/builder/tests/test_archetypes.py
@@ -24,3 +24,11 @@ class TestArchetypesBuilder(IntegrationTestCase):
         self.assertTrue(
             folder.checkCreationFlag(),
             'Creation flag should be True when disabling processForm')
+
+    def test_with_property(self):
+        folder = create(Builder('folder')
+                        .with_property('layout', 'folder_contents')
+                        .with_property('foo', 3, 'int'))
+
+        self.assertEquals('folder_contents', getattr(folder, 'layout', None))
+        self.assertEquals(3, getattr(folder, 'foo', None))

--- a/ftw/builder/tests/test_dexterity.py
+++ b/ftw/builder/tests/test_dexterity.py
@@ -203,6 +203,15 @@ class TestDexterityBuilder(DexterityBaseTestCase):
         self.assertEquals(creation_date, book.created())
         self.assertEquals(creation_date, obj2brain(book).created)
 
+    def test_with_property(self):
+        book = create(Builder('book')
+                      .with_property('layout', 'folder_contents')
+                      .with_property('foo', 3, 'int'))
+
+        self.assertEquals('folder_contents',
+                          getattr(aq_base(book), 'layout', None))
+        self.assertEquals(3, getattr(aq_base(book), 'foo', None))
+
     def test_initializes_relation_choice_relation_value_from_object(self):
         related = create(Builder('book'))
 


### PR DESCRIPTION
Extend content builders with a ``.with_property`` method.

The internal ``set_properties`` method call is in the AT and DX specific implementations in order to make sure that it happens before the object is indexed, as the indexers may depend on a correctly set property.

Closes #13