### PR TITLE
Add "ticking_creator", ticking a freezed clock.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -387,6 +387,38 @@ the ``force`` flag:
     builder_registry.register('file', CustomFileBuilder, force=True)
 
 
+Ticking frozen clock forward on create
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+With ``ftw.testing`` it is possible to
+`freeze the time <https://github.com/4teamwork/ftw.testing#freezing-datetime-now>`_.
+
+When freezing the time and creating multiple objects, they will all end up with
+the same creation date. This can cause an inconsistent sorting order.
+
+In order to solve this problem, ``ftw.builder`` provides a ``ticking_creator``,
+which moves the clock forward every time an object is created.
+This means we have distinct, consistent creation dates.
+
+Usage example:
+
+.. code:: python
+
+    from datetime import datetime
+    from ftw.builder import Builder
+    from ftw.builder import ticking_creator
+    from ftw.testing import freeze
+
+    with freeze(datetime(2010, 1, 1)) as clock:
+        create = ticking_creator(clock, days=1)
+        self.assertEquals(DateTime(2010, 1, 1),
+                          create(Builder('folder')).created())
+        self.assertEquals(DateTime(2010, 1, 2),
+                          create(Builder('folder')).created())
+        self.assertEquals(DateTime(2010, 1, 3),
+                          create(Builder('folder')).created())
+
+
 Other builders
 --------------
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.9.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add "ticking_creator", ticking a frozen clock. [jone]
 
 
 1.9.0 (2016-09-19)

--- a/ftw/builder/__init__.py
+++ b/ftw/builder/__init__.py
@@ -10,6 +10,7 @@ else:
 from ftw.builder.registry import builder_registry
 
 from ftw.builder.builder import Builder
+from ftw.builder.builder import ticking_creator
 from ftw.builder.builder import create
 
 import ftw.builder.content

--- a/ftw/builder/builder.py
+++ b/ftw/builder/builder.py
@@ -11,6 +11,19 @@ def create(builder, **kwargs):
     return builder.create(**kwargs)
 
 
+def ticking_creator(clock, **forward):
+    """Returns a builder create()-function, which "ticks" an
+    ftw.testing clock forward after each created object.
+    See https://github.com/4teamwork/ftw.testing#freezing-datetimenow
+    """
+    def ticking_create(*args, **kwargs):
+        try:
+            return create(*args, **kwargs)
+        finally:
+            clock.forward(**forward)
+    return ticking_create
+
+
 def Builder(name):
     if not session.current_session:
         raise Exception('There is no builder session - you need to use the '

--- a/ftw/builder/tests/test_builder.py
+++ b/ftw/builder/tests/test_builder.py
@@ -1,11 +1,14 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from datetime import datetime
 from DateTime import DateTime
-from Products.CMFCore.utils import getToolByName
 from ftw.builder import Builder
+from ftw.builder import ticking_creator
 from ftw.builder import create
 from ftw.builder.tests import IntegrationTestCase
+from ftw.testing import freeze
 from plone import api
+from Products.CMFCore.utils import getToolByName
 
 
 def obj2brain(obj):
@@ -103,3 +106,16 @@ class TestCreatingObjects(IntegrationTestCase):
         rid = catalog.getrid(path)
         index_data = catalog.getIndexDataForRID(rid)
         return index_data.get('allowedRolesAndUsers')
+
+
+class TestTickingCreator(IntegrationTestCase):
+
+    def test(self):
+        with freeze(datetime(2010, 1, 1)) as clock:
+            create = ticking_creator(clock, days=1)
+            self.assertEquals(DateTime(2010, 1, 1),
+                              create(Builder('folder')).created())
+            self.assertEquals(DateTime(2010, 1, 2),
+                              create(Builder('folder')).created())
+            self.assertEquals(DateTime(2010, 1, 3),
+                              create(Builder('folder')).created())

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ version = '1.9.1.dev0'
 tests_require = [
     'Acquisition',
     'ftw.testbrowser',
+    'ftw.testing',
     'plone.api',
     'plone.app.dexterity[relations]',
     'plone.app.testing',


### PR DESCRIPTION
With ``ftw.testing`` it is possible to
`freeze the time <https://github.com/4teamwork/ftw.testing#freezing-datetime-now>`_.

When freezing the time and creating multiple objects, they will all end up with
the same creation date. This can cause an inconsistent sorting order.

In order to solve this problem, ``ftw.builder`` provides a ``ticking_creator``,
which moves the clock forward after each time an object is created.
This means we have distinct, consistent creation dates.

Usage example:

```python
from datetime import datetime
from ftw.builder import Builder
from ftw.builder import ticking_creator
from ftw.testing import freeze

with freeze(datetime(2010, 1, 1)) as clock:
    create = ticking_creator(clock, days=1)
    self.assertEquals(DateTime(2010, 1, 1),
                      create(Builder('folder')).created())
    self.assertEquals(DateTime(2010, 1, 2),
                      create(Builder('folder')).created())
    self.assertEquals(DateTime(2010, 1, 3),
                      create(Builder('folder')).created())
```