### PR TITLE
fix for plone 5.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,8 @@ Setup builder session in your testcase
 
 .. code:: python
 
+    from ftw.builder import session
+
     class TestPerson(unittest2.TestCase):
 
         def setUp(self):

--- a/development.cfg
+++ b/development.cfg
@@ -1,4 +1,4 @@
 [buildout]
 extends =
-    test-plone-4.3.x.cfg
+    test-plone-5.1.x.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix test: test_object_providing_interface_updates_catalog: Asks catalog instead of index (query lazyness) [tarnap]
+- Fix dexterity image builder [tarnap]
 
 
 1.10.0 (2017-03-01)

--- a/ftw/builder/content.py
+++ b/ftw/builder/content.py
@@ -8,6 +8,7 @@ from StringIO import StringIO
 
 
 if HAVE_BLOBS:
+    from plone.namedfile.file import NamedImage
     from plone.namedfile.file import NamedBlobFile as NamedFile
 else:
     from plone.namedfile.file import NamedFile
@@ -107,6 +108,10 @@ class ImageBuilderMixin(FileBuilderMixin):
             self.arguments['image'] = file_
         else:
             self.arguments['file'] = file_
+        return self
+
+    def _attach_dx_file(self, content, name):
+        self.attach(NamedImage(data=content, filename=name))
         return self
 
 

--- a/ftw/builder/tests/test_content.py
+++ b/ftw/builder/tests/test_content.py
@@ -37,14 +37,14 @@ class TestContentBuilder(IntegrationTestCase):
         self.assertTrue(IFoo.providedBy(folder))
 
     def test_object_providing_interface_updates_catalog(self):
-        folder = create(Builder('folder').providing(IFoo))
+        create(Builder('folder').titled(u'providesIFoo').providing(IFoo))
+        create(Builder('folder').titled(u'doesnotprovideIFoo'))
 
-        catalog = getToolByName(folder, 'portal_catalog')
-        rid = catalog.getrid('/'.join(folder.getPhysicalPath()))
-        index_data = catalog.getIndexDataForRID(rid)
-
-        self.assertIn('ftw.builder.tests.test_content.IFoo',
-                      index_data['object_provides'])
+        catalog = getToolByName(self.portal, 'portal_catalog')
+        self.assertEquals(
+            ['providesIFoo'],
+            [brain.Title for brain in catalog(object_provides=IFoo.__identifier__)],
+        )
 
 
 class TestFolderBuilder(IntegrationTestCase):


### PR DESCRIPTION
also updated REAMDE to include the `import` statement importing `ftw.builder.session`

Thanks @maethu 