### PR TITLE
Make it possible to install a ticking creator globally.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -421,6 +421,30 @@ Usage example:
                           create(Builder('folder')).created())
 
 
+It is convenient to install the ticking creator globally, so if builder
+creates objects with another builder, it also ticks the clock for the
+nested builder call.
+This can be achieved by using the ticking creator as context manager:
+
+.. code:: python
+
+    from datetime import datetime
+    from ftw.builder import Builder
+    from ftw.builder import create
+    from ftw.builder import ticking_creator
+    from ftw.testing import freeze
+
+    with freeze(datetime(2010, 1, 1)) as clock:
+        with ticking_creator(clock, days=1):
+            self.assertEquals(DateTime(2010, 1, 1),
+                              create(Builder('folder')).created())
+            self.assertEquals(DateTime(2010, 1, 2),
+                              create(Builder('folder')).created())
+            self.assertEquals(DateTime(2010, 1, 3),
+                              create(Builder('folder')).created())
+
+
+
 Other builders
 --------------
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
+- Make ticking creator installable globally by using as context manager. [jone]
 - Fix test: test_object_providing_interface_updates_catalog: Asks catalog instead of index (query lazyness) [tarnap]
 - Fix dexterity image builder [tarnap]
 

--- a/ftw/builder/tests/test_builder.py
+++ b/ftw/builder/tests/test_builder.py
@@ -110,7 +110,7 @@ class TestCreatingObjects(IntegrationTestCase):
 
 class TestTickingCreator(IntegrationTestCase):
 
-    def test(self):
+    def test_ticking_creator_function(self):
         with freeze(datetime(2010, 1, 1)) as clock:
             create = ticking_creator(clock, days=1)
             self.assertEquals(DateTime(2010, 1, 1),
@@ -119,3 +119,13 @@ class TestTickingCreator(IntegrationTestCase):
                               create(Builder('folder')).created())
             self.assertEquals(DateTime(2010, 1, 3),
                               create(Builder('folder')).created())
+
+    def test_activating_ticking_creator_in_context_manager(self):
+        with freeze(datetime(2010, 1, 1)) as clock:
+            with ticking_creator(clock, days=1):
+                self.assertEquals(DateTime(2010, 1, 1),
+                                  create(Builder('folder')).created())
+                self.assertEquals(DateTime(2010, 1, 2),
+                                  create(Builder('folder')).created())
+                self.assertEquals(DateTime(2010, 1, 3),
+                                  create(Builder('folder')).created())


### PR DESCRIPTION
In order to let nested creators tick the clock too, the ticking creator can be installed globally when used as context manager.

In order to support replacing the creator a chain is used internally, allowing to register any amount of creator wrappers without the need to monkey patch the create function.

Usage example:
```python

from datetime import datetime
from ftw.builder import Builder
from ftw.builder import create
from ftw.builder import ticking_creator
from ftw.testing import freeze

with freeze(datetime(2010, 1, 1)) as clock:
    with ticking_creator(clock, days=1):
        self.assertEquals(DateTime(2010, 1, 1),
                          create(Builder('folder')).created())
        self.assertEquals(DateTime(2010, 1, 2),
                          create(Builder('folder')).created())
        self.assertEquals(DateTime(2010, 1, 3),
                          create(Builder('folder')).created())
```