### PR TITLE
Fix tests for Plone 5.

### DIFF
--- a/ftw/builder/tests/test_genericsetup_profile_builder.py
+++ b/ftw/builder/tests/test_genericsetup_profile_builder.py
@@ -75,14 +75,16 @@ class TestGenericSetupProfileBuilder(TestCase):
 
     def test_dependencies(self):
         package = create(self.package_builder
+                         .with_profile(Builder('genericsetup profile').named('foo'))
+                         .with_profile(Builder('genericsetup profile').named('bar'))
                          .with_profile(Builder('genericsetup profile')
-                                       .with_dependencies('collective.foo:default',
-                                                          'profile-collective.bar:default')))
+                                       .with_dependencies('the.package:foo',
+                                                          'profile-the.package:bar')))
 
         with package.zcml_loaded(self.layer['configurationContext']):
             self.assertEquals(
-                (u'profile-collective.foo:default',
-                 u'profile-collective.bar:default'),
+                (u'profile-the.package:foo',
+                 u'profile-the.package:bar'),
                 self.genericsetup.getDependenciesForProfile('the.package:default'))
 
     def get_profile_info(self, profile_id):


### PR DESCRIPTION
The test was relying on the fact that `getDependenciesForProfile` did not check whether the profiles actually exist. But this was changed from Plone 4 to 5, `getDependenciesForProfile` now verifies that the profiles actually exist.

The test is rewritten to use actually generated profiles, so that the verification passes.