### PR TITLE
Bump collective.xmltestreport to 2.0.2.

### DIFF
--- a/test-plone-5.2.x.cfg
+++ b/test-plone-5.2.x.cfg
@@ -4,3 +4,6 @@ extends =
     sources.cfg
 
 package-name = ftw.builder
+
+[versions]
+collective.xmltestreport = 2.0.2


### PR DESCRIPTION
For compatibility with zope.testrunner 5.1+. Otherwise failing tests cannot be reported correctly and will themselves fail.